### PR TITLE
Use arrays instead of flattened lists for points

### DIFF
--- a/dualGPy/Geometry.py
+++ b/dualGPy/Geometry.py
@@ -40,7 +40,7 @@ class Face2D(Face) :
         self.segments = segments
         self.leng_segments = []
         super().__init__(*args, **kwargs)
-        self.n_vertices = int(len(self.points)/2)
+        self.n_vertices = self.points.shape[0]
 
     @staticmethod
     @njit
@@ -50,9 +50,8 @@ class Face2D(Face) :
         return area_0
 
     def ComputeArea(self):
-        cell_points_reshaped=np.reshape(self.points,(self.n_vertices,2))
-        shifted = np.roll(cell_points_reshaped, 1, axis=0)
-        area_0 = self.algebric_area(cell_points_reshaped,shifted)
+        shifted = np.roll(self.points, 1, axis=0)
+        area_0 = self.algebric_area(self.points,shifted)
         self.area = abs(area_0)
 
     def ComputeLength(self,global_points):
@@ -63,11 +62,10 @@ class Face2D(Face) :
 class Face3D(Face) :
     def __init__(self,*args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.n_vertices = int(len(self.points)/3)
-        self.points_reshaped = np.reshape(self.points,(self.n_vertices,3))
-        self.a = self.points_reshaped[0]
-        self.b = self.points_reshaped[1]
-        self.c = self.points_reshaped[2]
+        self.n_vertices = self.points.shape[0]
+        self.a = self.points[0,:]
+        self.b = self.points[1,:]
+        self.c = self.points[2,:]
 
     def unit_normal(self):
         x = np.linalg.det([[1,self.a[1],self.a[2]],
@@ -87,7 +85,7 @@ class Face3D(Face) :
     def ComputeArea(self):
         #https://stackoverflow.com/questions/12642256/find-area-of-polygon-from-xyz-coordinates
         #shape (N, 3)
-        poly = self.points_reshaped
+        poly = self.points
         #all edges
         edges = poly[1:] - poly[0:1]
         # row wise cross product
@@ -159,48 +157,41 @@ class Solid(abc.ABC):
 class Tetra(Solid):
     def __init__(self,*args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.n_vertices = int(len(self.points)/3)
+        self.n_vertices = self.points.shape[0]
         assert(self.n_vertices==4)
     def ComputeArea(self,global_points):
         """ compute the Area of the faces of the cell with respect to the dimensionality """
         if self.Faces:
-         points = []
          for faccia in self.Faces:
-             for i,e in enumerate(faccia):
-                 points.extend(global_points[e])
+             points = global_points[faccia, :]
              faccia_el = Face3D(points)
              faccia_el.ComputeArea()
              self.AreaFaces.append(faccia_el.area)
-             points = []
     def ComputeVolume(self):
         """ compute the Volume of  of the cells with respect to the dimensionality """
         # https://stackoverflow.com/questions/9866452/calculate-volume-of-any-tetrahedron-given-4-points
-        mat = np.array(self.points)
-        mat_1=np.reshape(mat,(self.n_vertices,3)).transpose()
-        mat_2=  np.vstack([mat_1,np.ones((1,4))])
+        mat_1 = self.points.transpose()
+        mat_2 = np.vstack([mat_1,np.ones((1,4))])
         self.volume= 1/6*abs(np.linalg.det(mat_2))
 
 class Hexa(Solid):
     def __init__(self,*args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.n_vertices = int(len(self.points)/3)
+        self.n_vertices = self.points.shape[0]
         assert(self.n_vertices==8)
     def ComputeArea(self,global_points):
         """ compute the Area of the faces of the cell with respect to the dimensionality """
         if self.Faces:
-         points = []
          for faccia in self.Faces:
-             for i,e in enumerate(faccia):
-                 points.extend(global_points[e])
+             points = global_points[faccia, :]
              faccia_el = Face3D(points)
              faccia_el.ComputeArea()
              self.AreaFaces.append(faccia_el.area)
-             points = []
     def ComputeVolume(self):
         """ compute the Volume of  of the cells with respect to the dimensionality """
         # https://math.stackexchange.com/questions/1628540/what-is-the-enclosed-volume-of-an-irregular-cube-given-the-x-y-z-coordinates-of/1628872#1628872
 #        mat = self.points
-        mat_diag=np.reshape(self.points,(self.n_vertices,3)).transpose()
+        mat_diag=self.points.transpose()
 #        mat_1=np.reshape(mat_half,(3,8)).transpose()
 #        mat_upper0 = np.vstack([mat_1[0:3,:],mat_1[4,:]])
 #        mat_upper=  np.vstack([mat_upper0.transpose(),np.ones((1,4))])

--- a/dualGPy/Mesh.py
+++ b/dualGPy/Mesh.py
@@ -252,22 +252,14 @@ class Mesh2D(Mesh) :
     def ComputeGeometry(self):
         """ Specific implementation of the correspective method in :class:`Mesh`."""
         # points of the specific cell
-        cell_points=[]
         # cycle on the cells
         for i,cell in enumerate(self.cells):
-        # cycle on the indexes
-            for index in cell:
-        # accumulating the cell points
-                cell_points.extend(self.mesh.points[index])
         # applying shoelace formula
-        # 1. reshape the cell points vector to operate directly with vectors, avoiding unnecessary loops
-        # 2. apply the shoelace
-            cella = Face2D(self.faces[i],cell_points)
+            cella = Face2D(self.faces[i], self.mesh.points[cell, :])
             cella.ComputeArea()
             cella.ComputeLength(self.mesh.points)
             self.volume.append(cella.area)
             self.area.extend(cella.leng_segments)
-            cell_points =[]
 
     def boundary_detection_Easy(self):
       """ automatically determine the boundary condition, starting from the given graph
@@ -442,27 +434,19 @@ class Mesh3D(Mesh):
 
 
     def ComputeGeometry(self):
-        """ In the case of the 2D class it will be an Area """
+        """ In the case of the 3D class it will be an Area """
         # points of the specific cell
-        cell_points=[]
         # cycle on the cells
         for i,cell in enumerate(self.cells):
-        # cycle on the indexes
-            for index in cell:
-        # accumulating the cell points
-                cell_points.extend(self.mesh.points[index])
         # applying shoelace formula
-        # 1. reshape the cell points vector to operate directly with vectors, avoiding unnecessary loops
-        # 2. apply the shoelace
-            if len(cell_points)==12: #4*3
-               cella = Tetra(cell_points,self.faces[i])
+            if len(cell) == 4:
+               cella = Tetra(self.mesh.points[cell, :],self.faces[i])
             else:
-               cella= Hexa(cell_points,self.faces[i])
+               cella = Hexa(self.mesh.points[cell, :],self.faces[i])
             cella.ComputeArea(self.mesh.points)
             cella.ComputeVolume()
 #            self.volume.append(cella.volume)
             self.area.extend(cella.AreaFaces)
-            cell_points =[]
     def boundary_detection(self):
      """ automatically determine the boundary condition
          Right now we generate all the combination of possible faces and we see if they

--- a/dualGPy/Mesh.py
+++ b/dualGPy/Mesh.py
@@ -93,6 +93,8 @@ class Mesh2D(Mesh) :
            points =[]
            cells_test = []
            n = args[0]
+           if n < 2:
+               raise ValueError(f'Number of nodes per edge should be at least 2 (got {n})')
            anisotropic = args[1]
            points = [ [j,i] for i,j in product(range(n),range(n)) ]
            if anisotropic:
@@ -371,6 +373,8 @@ class Mesh3D(Mesh):
            points = []
            cells_test = []
            n = args[0]
+           if n < 2:
+               raise ValueError(f'Number of nodes per edge should be at least 2 (got {n})')
            anisotropic = args[1]
            points = [ [k,j,i] for i,j,k in product(range(n), range(n), range(n)) ]
            if anisotropic:

--- a/tests/test_Geometry.py
+++ b/tests/test_Geometry.py
@@ -6,12 +6,12 @@ from dualGPy.Geometry import Face3D
 import numpy as np
 class Test3D:
     def test_square(self):
-        points =  np.array([0,0,0,1,0,0,1,1,0,0,1,0])
+        points =  np.array([[0,0,0],[1,0,0],[1,1,0],[0,1,0]])
         Face = Face3D(points)
         Face.ComputeArea()
         assert(Face.area==1)
     def test_triangle(self):
-        points =  np.array([0,0,0,1,0,0,0.5,1,0])
+        points =  np.array([[0,0,0],[1,0,0],[0.5,1,0]])
         Face = Face3D(points)
         Face.ComputeArea()
         assert(Face.area==0.5)


### PR DESCRIPTION
So far in `ComputeGeometry` points are flattened in one list, passed to `Face2D` (resp. `3D`) where they are put back into matrix form of shape `(n_vertices, 2)' (resp. `3`). This avoids doing unnecessary works and keeps the matrix form.

This PR passes the test of the present repository. It passes 2D coupling tests with `CoMMA` (with and without anisotropy). However, unfortunately, when running this kind of tests in 3D I got a segmentation fault.